### PR TITLE
#1 [chore] 프로젝트 기초 세팅 변경 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 
     // serialization
     implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1"
 
     // timber
     implementation "com.jakewharton.timber:timber:5.0.1"
@@ -94,7 +94,7 @@ dependencies {
 
     // Glide
     implementation "com.github.bumptech.glide:glide:4.15.1"
-    kapt "com.github.bumptech.glide:compiler:4.13.2"
+    kapt "com.github.bumptech.glide:compiler:4.15.1"
 
     // Sticky Scroll View
     implementation "com.github.amarjain07:StickyScrollView:1.0.3"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,12 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
+    id 'kotlin-parcelize'
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.10'
 }
+
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 android {
     namespace 'com.sopt.baemin'
@@ -17,6 +21,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField "String", "BASE_URL", properties["base.url"]
     }
 
     buildTypes {
@@ -39,49 +44,58 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    // ktx
+    implementation "androidx.fragment:fragment-ktx:1.5.7"
 
-    // Ktx
-    implementation "androidx.activity:activity-ktx:$activity_ktx_version"
-    implementation "androidx.fragment:fragment-ktx:$fragment_ktx_version"
+    // app compat
+    implementation "androidx.appcompat:appcompat:1.6.1"
 
-    // ViewModel
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+    // material
+    implementation "com.google.android.material:material:1.9.0"
+
+    // constraint layout
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+
+    // test
+    testImplementation "junit:junit:4.13.2"
+    androidTestImplementation "androidx.test.ext:junit:1.1.5"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+
+    // lifecycle
+    implementation "androidx.legacy:legacy-support-v4:1.0.0"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
+
+    // coroutine
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
+
+    // network
+    implementation "com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.11"
+    implementation "com.google.code.gson:gson:2.10.1"
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+
+    // coil
+    implementation "io.coil-kt:coil:2.4.0"
+
+    // serialization
+    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
+
+    // timber
+    implementation "com.jakewharton.timber:timber:5.0.1"
+
+    // shared preference
+    implementation "androidx.security:security-crypto-ktx:1.1.0-alpha06"
+
+    // splash screen
+    implementation "androidx.core:core-splashscreen:1.0.1"
 
     // Glide
-    implementation "com.github.bumptech.glide:glide:$glide_version"
-    kapt "com.github.bumptech.glide:compiler:$glide_version"
-
-    // Retrofit
-    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
-
-    // Okhttp
-    implementation platform("com.squareup.okhttp3:okhttp-bom:$okhttp_version")
-    implementation "com.squareup.okhttp3:okhttp"
-    implementation "com.squareup.okhttp3:logging-interceptor"
-
-    // Kotlinx - Serialization
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinx_serialization_version"
-    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:$kotlinx_serialization_converter_version"
+    implementation "com.github.bumptech.glide:glide:4.15.1"
+    kapt "com.github.bumptech.glide:compiler:4.13.2"
 
     // Sticky Scroll View
-    implementation "com.github.amarjain07:StickyScrollView:$sticky_version"
-
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
-
-    //noinspection GradleCompatible
-    implementation 'com.android.support:design:28.0.0'
-
-    // Coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
-
-    implementation 'de.hdodenhof:circleimageview:3.1.0'
+    implementation "com.github.amarjain07:StickyScrollView:1.0.3"
 }

--- a/app/src/main/java/com/sopt/baemin/data/api/ApiFactory.kt
+++ b/app/src/main/java/com/sopt/baemin/data/api/ApiFactory.kt
@@ -1,0 +1,36 @@
+package com.sopt.baemin.data.api
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.sopt.baemin.BuildConfig.*
+import com.sopt.baemin.data.service.ExampleService
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+
+object ApiFactory {
+    private const val CONTENT_TYPE = "application/json"
+
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(
+            HttpLoggingInterceptor().apply {
+                if (DEBUG) HttpLoggingInterceptor.Level.BODY
+                else HttpLoggingInterceptor.Level.NONE
+            })
+        .build()
+
+    @OptIn(ExperimentalSerializationApi::class)
+    val retrofit: Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .addConverterFactory(Json.asConverterFactory(CONTENT_TYPE.toMediaType()))
+        .client(okHttpClient)
+        .build()
+
+    inline fun <reified T> create(): T = retrofit.create(T::class.java)
+
+    object ServicePool {
+        val exampleService = create<ExampleService>()
+    }
+}

--- a/app/src/main/java/com/sopt/baemin/data/model/request/RequestDto.kt
+++ b/app/src/main/java/com/sopt/baemin/data/model/request/RequestDto.kt
@@ -1,0 +1,5 @@
+package com.sopt.baemin.data.model.request
+
+data class RequestDto(
+    val test: String
+)

--- a/app/src/main/java/com/sopt/baemin/data/model/response/BaseResponse.kt
+++ b/app/src/main/java/com/sopt/baemin/data/model/response/BaseResponse.kt
@@ -1,0 +1,16 @@
+package com.sopt.baemin.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BaseResponse<T>(
+    @SerialName("status")
+    val status: Int,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: T? = null
+)

--- a/app/src/main/java/com/sopt/baemin/data/model/response/ResponseDto.kt
+++ b/app/src/main/java/com/sopt/baemin/data/model/response/ResponseDto.kt
@@ -1,0 +1,5 @@
+package com.sopt.baemin.data.model.response
+
+data class ResponseDto(
+    val test: String
+)

--- a/app/src/main/java/com/sopt/baemin/data/service/ExampleService.kt
+++ b/app/src/main/java/com/sopt/baemin/data/service/ExampleService.kt
@@ -1,0 +1,5 @@
+package com.sopt.baemin.data.service
+
+interface ExampleService {
+    // 서버 통신에 사용되는 HTTP 메서드 선언
+}

--- a/app/src/main/java/com/sopt/baemin/presentation/MainActivity.kt
+++ b/app/src/main/java/com/sopt/baemin/presentation/MainActivity.kt
@@ -1,12 +1,13 @@
 package com.sopt.baemin.presentation
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import com.sopt.baemin.R
+import com.sopt.baemin.databinding.ActivityMainBinding
+import com.sopt.baemin.util.binding.BindingActivity
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+
     }
 }

--- a/app/src/main/java/com/sopt/baemin/util/binding/BindingActivity.kt
+++ b/app/src/main/java/com/sopt/baemin/util/binding/BindingActivity.kt
@@ -6,12 +6,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 
-abstract class BindingActivity<T : ViewDataBinding>(@LayoutRes private val layoutRes: Int) :
-    AppCompatActivity() {
+abstract class BindingActivity<T : ViewDataBinding>(
+    @LayoutRes val layoutRes: Int
+) : AppCompatActivity() {
     protected lateinit var binding: T
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, layoutRes)
+        binding.lifecycleOwner = this@BindingActivity
     }
 }

--- a/app/src/main/java/com/sopt/baemin/util/binding/BindingFragment.kt
+++ b/app/src/main/java/com/sopt/baemin/util/binding/BindingFragment.kt
@@ -8,12 +8,13 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
+import com.sopt.baemin.R
 
 abstract class BindingFragment<T : ViewDataBinding>(@LayoutRes private val layoutRes: Int) :
     Fragment() {
     private var _binding: T? = null
     protected val binding: T
-        get() = requireNotNull(_binding) { "${this::class.java.simpleName} error." }
+        get() = requireNotNull(_binding) { getString(R.string.binding_error_msg) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -21,6 +22,7 @@ abstract class BindingFragment<T : ViewDataBinding>(@LayoutRes private val layou
         savedInstanceState: Bundle?
     ): View {
         _binding = DataBindingUtil.inflate(inflater, layoutRes, container, false)
+        binding.lifecycleOwner = viewLifecycleOwner
         return binding.root
     }
 

--- a/app/src/main/java/com/sopt/baemin/util/extension/ActivityExt.kt
+++ b/app/src/main/java/com/sopt/baemin/util/extension/ActivityExt.kt
@@ -6,9 +6,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 
-inline fun <reified T : Fragment> AppCompatActivity.oreplace(@IdRes frameId: Int) {
+inline fun <reified T : Fragment> AppCompatActivity.replace(@IdRes fcvId: Int) {
     supportFragmentManager.commit {
-        replace<T>(frameId)
+        replace<T>(fcvId)
         setReorderingAllowed(true)
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.sopt.baemin.presentation.MainActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/tv_mini_player_title_main"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:text="홈"
-        android:textColor="@color/black" />
+    <data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.sopt.baemin.presentation.MainActivity">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Hello World"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Baemin</string>
+
+    <string name="binding_error_msg">Binding not initialized to reference the view.</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,5 +7,5 @@ plugins {
 
 ext {
     lifecycleVersion = '2.6.1'
-    coroutineVersion = '1.6.4'
+    coroutineVersion = '1.7.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
 }
 
 ext {
-    activity_ktx_version = '1.6.0'
-    fragment_ktx_version = '1.5.3'
-    lifecycle_version = '2.5.1'
-    glide_version = '4.12.0'
-    retrofit_version = '2.9.0'
-    gson_version = '2.9.1'
-    okhttp_version = '4.10.0'
-    kotlinx_serialization_version = '1.4.1'
-    kotlinx_serialization_converter_version = '0.8.0'
-    sticky_version = '1.0.3'
+    lifecycleVersion = '2.6.1'
+    coroutineVersion = '1.6.4'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 28 16:03:15 KST 2022
+#Thu May 25 03:28:57 KST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 관련 이슈

- #1 

## 작업한 내용

- 프로젝트 및 모듈 단위의 build.gradle -> 최신 버전으로 업데이트  
- 서버 base url 버전 관리하지 않도록  (local.properties) 
- 서버 통신을 위한 기본 패키지 설정 (data, api, service, model 등) 
- 바인딩 액티비티, 프래그먼트 라이프사이클 Owner 설정 

## PR 포인트 

![image](https://github.com/GOSOPT-CDS-BAEMIN/Android/assets/68090939/58813660-4b3a-4086-861b-f0af80ace661)

![image](https://github.com/GOSOPT-CDS-BAEMIN/Android/assets/68090939/26545b3d-3672-45c2-974c-ce6fcba5ea05)

- 프로젝트 단위의 build.gradle 파일에 모든 의존성 버전을 선언하면, 모듈 단위의 build.gradle 파일에서 alt + enter 키 이용해서 최신 버전으로 업데이트 하기 어렵더라구요..! 그래서 여러 번 사용되는 lifecycleVersion, coroutineVersion만 ext에 선언하도록 변경했습니다!
- 그래들 플러그인 버전, 코틀린 버전도 각각 `7.4.2`, `1.8.21`로 업데이트 했어요! 



